### PR TITLE
Added default headers to ansible.cfg

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,1 +1,2 @@
+[defaults]
 ANSIBLE_STDOUT_CALLBACK=debug


### PR DESCRIPTION
Added default headers to solve the "File contains no section headers." error when running 
```
sudo ansible-playbook init.yml
```