### PR TITLE
Added local dev TLS cert instructions to readme.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ If you wish to contribute, please join our Discord located at: https://discord.g
 
 The PS2Alerts project utilises Kubernetes for its deployment and containerisation solution. It matches current infrastructure, and it solves a TON of headaches when it comes to getting code out to the world. Particularly SSL certificates. Fuck SSL certificate management. Locally however, for the sake of lowering local dev environment complexity and "things doing weird stuff" we're using Ansible to provision and maintain the local development environment. It will install not only the services required to run the application, but also a set of standardized commands shared across all developers.
 
-**Linux Debian** and **Mac OSX Catalina** are the only supported operating systems for development. It can be done in Windows, but it's a hassle. Mac OSX does work with `homebrew` filling some gaps. **Windows is not officially supported.**
+**Linux Debian** and **Mac OSX Catalina** are the only supported operating systems for development. It can be done in Windows, but it's a hassle. If you feel the need to develop on Windows, [WSL2](https://docs.microsoft.com/en-us/windows/wsl/install) will be much easier to set up. Mac OSX does work with `homebrew` filling some gaps. **Windows is not officially supported.**
 
 ## Requirements
 
@@ -45,6 +45,69 @@ Simply execute `ps2alerts-init` in your terminal to begin! This will go off to e
 Once the project has fully initialized, you can start the project from now on using `ps2alerts-start`!
 
 We have designed the aggregator project (potentially moved to API) to initialize the database for you, it also triggers an "instance" of your choosing via code so you're able to quicky start tracking data. Check it's readme for more information.
+
+
+## Adding certificates for local dev HTTPS access
+
+If you want to access the dev environment over HTTPS (Say, because Chrome forces it), you'll need to follow some additional steps:
+<details>
+    <summary>Expand certificate instructions...</summary>
+
+1. The following needs to be added to `traefik/config/config.yml`
+    ```yaml
+    tls:
+      stores:
+        default:
+          defaultCertificate:
+            certFile: /etc/certs/api.dev.ps2alerts.com.pem
+            keyFile: /etc/certs/api.dev.ps2alerts.com-key.pem
+      certificates:
+      - certFile: /etc/certs/api.dev.ps2alerts.com.pem
+        keyFile: /etc/certs/api.dev.ps2alerts.com-key.pem
+      - certFile: /etc/certs/dev.ps2alerts.com.pem
+        keyFile: /etc/certs/dev.ps2alerts.com-key.pem
+      - certFile: /etc/certs/wss.dev.ps2alerts.com.pem
+        keyFile: /etc/certs/wss.dev.ps2alerts.com-key.pem
+    ```
+2. The referenced certificates must be generated and placed in the ~/ps2alerts/certs/ directory. To generate **local** self-signed certs:
+   Steps generally referenced from: https://www.section.io/engineering-education/how-to-get-ssl-https-for-localhost/
+    - `cd ~/ps2alerts/certs`
+    - `openssl genrsa -out CA.key -des3 2048`
+    - `openssl req -x509 -sha256 -new -nodes -days 3650 -key CA.key -out CA.pem`
+    - `touch ps2alerts_dev.ext`
+        ```txt    
+        # Add the following contents to ~/ps2alerts/certs/ps2alerts_dev.ext:
+        authorityKeyIdentifier = keyid,issuer
+        basicConstraints = CA:FALSE
+        keyUsage = digitalSignature, nonRepudiation, keyEncipherment, dataEncipherment
+        subjectAltName = @alt_names
+
+        [alt_names]
+        DNS.1 = localhost
+        DNS.2 = dev.ps2alerts.com
+        DNS.3 = dev.api.ps2alerts.com
+        DNS.4 = dev.router.ps2alerts.com
+        IP.1 = 127.0.0.1
+        IP.2 = 127.0.0.1
+        IP.3 = 127.0.0.1
+        IP.4 = 127.0.0.1
+        ```
+    - `openssl genrsa -out ps2alerts_dev.key -des3 2048`
+    - `openssl req -new -key ps2alerts_dev.key -out ps2alerts_dev.csr`
+    - `openssl x509 -req -in ps2alerts_dev.csr -CA CA.pem -CAkey CA.key -CAcreateserial -days 3650 -sha256 -extfile ps2alerts_dev.ext -out api.dev.ps2alerts.com.pem`
+    - `openssl rsa -in ps2alerts_dev.key -out api.dev.ps2alerts.com-key.pem`
+    - `cp api.dev.ps2alerts.com-key.pem dev.ps2alerts.com-key.pem && cp api.dev.ps2alerts.com.pem dev.ps2alerts.com.pem`
+    - `cp api.dev.ps2alerts.com-key.pem wss.dev.ps2alerts.com-key.pem && cp api.dev.ps2alerts.com.pem wss.dev.ps2alerts.com.pem`
+    - Add ~/ps2alerts/certs/CA.pem as a trusted CA cert to browsers you will be using to connect to dev.ps2alerts.com
+3. In `traefik/traefik.yml`, uncomment the following section:
+    ```yaml
+     # # HTTPS/TLS certificate configuration
+     # file:
+     #  filename:
+     #     /config/config.yml
+    ```
+
+</details>
 
 # How to get data collection going
 

--- a/traefik/traefik.yml
+++ b/traefik/traefik.yml
@@ -2,6 +2,10 @@
 providers:
   docker:
     exposedByDefault: false
+  # # HTTPS/TLS certificate configuration
+  # file:
+  #  filename:
+  #     /config/config.yml
 
 accessLog:
   filePath: "/var/log/traefik/traefik-access.log"


### PR DESCRIPTION
This pull request adds documentation of the steps I went through to get local dev environment certificates created and working on my windows machine with WSL2 and Chrome.