### PR TITLE
Add migration for mapVersion

### DIFF
--- a/mongo/migrations/20220301012334-convert_to_adjusted_battle_rank.js
+++ b/mongo/migrations/20220301012334-convert_to_adjusted_battle_rank.js
@@ -1,44 +1,42 @@
 module.exports = {
   async up(db) {
-    let filter = {"character.asp": true};
+    let filter = {"character.asp": true, "character.id": {"$ne": null}};
     let updateDoc = [{"$set":{"character.asp": 1, "character.adjustedBattleRank": {"$add": ["$character.battleRank", 120]}}}];
-    let options = { upsert: true };
 
     console.log("Updating ASP = true characters...");
-    const result = await db.collection("aggregate_global_characters").updateMany(filter, updateDoc, options);
+    const result = await db.collection("aggregate_global_characters").updateMany(filter, updateDoc);
     console.log(`${result.matchedCount} document(s) matched the filter, updated ${result.modifiedCount} document(s)\n`);
 
     console.log("Updating ASP = false characters (Some of these are ASP2 but they should eventually be picked up by death events)...");
     filter["character.asp"] = false;
     updateDoc[0]["$set"]["character.adjustedBattleRank"]["$add"][1] = 0;
     updateDoc[0]["$set"]["character.asp"] = 0;
-    const result2 = await db.collection("aggregate_global_characters").updateMany(filter, updateDoc, options);
+    const result2 = await db.collection("aggregate_global_characters").updateMany(filter, updateDoc);
     console.log(`${result2.matchedCount} document(s) matched the filter, updated ${result2.modifiedCount} document(s)\n`);
 
     filter["character.asp"] = null;
     console.log("Updating ASP = null characters (PS4)...");
-    const result3 = await db.collection("aggregate_global_characters").updateMany(filter, updateDoc, options);
+    const result3 = await db.collection("aggregate_global_characters").updateMany(filter, updateDoc);
     console.log(`${result3.matchedCount} document(s) matched the filter, updated ${result3.modifiedCount} document(s)`);
 
     filter["character.asp"] = undefined;
     console.log("Updating ASP = undefined characters (PS4)...");
-    const result4 = await db.collection("aggregate_global_characters").updateMany(filter, updateDoc, options);
-    console.log(`${result3.matchedCount} document(s) matched the filter, updated ${result4.modifiedCount} document(s)`);
+    const result4 = await db.collection("aggregate_global_characters").updateMany(filter, updateDoc);
+    console.log(`${result3.matchedCount} document(s) matched the filter, updated ${result4.modifiedCount} document(s)\n`);
   },
 
   async down(db) {
     let filter = {"character.asp": 1};
     let updateDoc = [{"$set": { "character.asp": true }}, {"$unset": "character.adjustedBattleRank"}];
-    let options = { upsert: true };
 
     console.log("Reverting ASP1 characters...");
-    const result = await db.collection("aggregate_global_characters").updateMany(filter, updateDoc, options);
+    const result = await db.collection("aggregate_global_characters").updateMany(filter, updateDoc);
     console.log(`${result.matchedCount} document(s) matched the filter, updated ${result.modifiedCount} document(s)\n`);
 
     console.log("Reverting non-ASP and ASP2 characters...");
     filter = {$or: [{"character.asp": 0}, {"character.asp": 2}]};
     updateDoc[0]["$set"]["character.asp"] = false;
-    const result2 = await db.collection("aggregate_global_characters").updateMany(filter, updateDoc, options);
+    const result2 = await db.collection("aggregate_global_characters").updateMany(filter, updateDoc);
     console.log(`${result2.matchedCount} document(s) matched the filter, updated ${result2.modifiedCount} document(s)`);
   }
 };

--- a/mongo/migrations/20220714215400-add_map_versions.js
+++ b/mongo/migrations/20220714215400-add_map_versions.js
@@ -1,0 +1,29 @@
+module.exports = {
+  async up(db) {
+    let filter = {"timeStarted": {"$lte": new Date(2022, 07, 13, 13)}, "mapVersion": {"$exists": false}};
+    let updateDoc = [{"$set":{"mapVersion": "1.0"}}];
+
+    console.log(`Updating instances created prior to the Surf and Storm Update...`);
+    let result = await db.collection("instance_metagame_territories").updateMany(filter, updateDoc);
+    console.log(`${result.matchedCount} document(s) matched the filter, updated ${result.modifiedCount} document(s)\n`);
+
+    filter = {"timeStarted": {"$gt": new Date(2022, 07, 13, 13)}, "mapVersion": {"$exists": false}, "zone": {"$ne": 344}};
+    console.log(`Updating unversioned, non-Oshur instances created after the Surf and Storm Update...`);
+    result = await db.collection("instance_metagame_territories").updateMany(filter, updateDoc);
+    console.log(`${result.matchedCount} document(s) matched the filter, updated ${result.modifiedCount} document(s)\n`);
+
+    filter = {"timeStarted": {"$gt": new Date(2022, 07, 13, 13)}, "mapVersion": {"$exists": false}, "zone": 344};
+    console.log(`Updating unversioned Oshur instances created after the Surf and Storm Update...`);
+    updateDoc = [{"$set":{"mapVersion": "1.1"}}];
+    result = await db.collection("instance_metagame_territories").updateMany(filter, updateDoc);
+    console.log(`${result.matchedCount} document(s) matched the filter, updated ${result.modifiedCount} document(s)\n`);
+  },
+
+  async down(db) {
+    const updateDoc = [{"$unset":{"mapVersion": 1}}];
+
+    console.log(`Removing mapVersions from all alert instances...\n`);
+    const result = await db.collection("instance_metagame_territories").updateMany({}, updateDoc);
+    console.log(`Updated ${result.modifiedCount} document(s)\n`);
+  }
+};


### PR DESCRIPTION
This PR adds a migration that can be run to add mapVersions to instances created before the surf and storm update was supported by PS2Alerts.

It will add the version "1.0" to everything created before 7/13/22 6AM PT (when the servers went down) and all non-Oshur instances created after the update. Oshur instances created after the update will have the version "1.1" added.

This also fixes a bug with the previous ASP2 migration which I did not encounter before because I did not test it on a DB that already had full ASP2 support

The migration was created with migrate-mongo@8.2.3, it appears that the latest 9.0.0 version is not working correctly, so make sure when applying the migration you've installed the correct version.