### PR TITLE
Add Lattice Versioning separate from Map Tile versioning

### DIFF
--- a/mongo/migrate-mongo-config.js
+++ b/mongo/migrate-mongo-config.js
@@ -24,6 +24,8 @@ const config = {
   // The file extension to create migrations and search for in migration dir
   migrationFileExtension: ".js",
 
+  moduleSystem: 'commonjs',
+
   // Enable the algorithm to create a checksum of the file contents and use that in the comparison to determin
   // if the file should be run.  Requires that scripts are coded to be run multiple times.
   useFileHash: false

--- a/mongo/migrations/20220714215400-add_map_versions.js
+++ b/mongo/migrations/20220714215400-add_map_versions.js
@@ -20,7 +20,7 @@ module.exports = {
   },
 
   async down(db) {
-    const updateDoc = [{"$unset":{"mapVersion": 1}}];
+    const updateDoc = [{"$unset": "mapVersion"}];
 
     console.log(`Removing mapVersions from all alert instances...\n`);
     const result = await db.collection("instance_metagame_territories").updateMany({}, updateDoc);

--- a/mongo/migrations/20220828152940-event_type_aggregate.js
+++ b/mongo/migrations/20220828152940-event_type_aggregate.js
@@ -21,13 +21,25 @@ const aggregateCollections = [
 
 module.exports = {
   async up(db) {
+    let filter = {"ps2AlertsEventType": {"$exists": true}};
+    for (let i = 0; i < aggregateCollections.length;) {
+      const collection = aggregateCollections[i];
+      const result = await db.collection(collection).findOne(filter);
+      if(result !== null) {
+        const index = aggregateCollections.indexOf(collection);
+        aggregateCollections.splice(index, 1);
+      } else {
+        i++;
+      }
+    }
+    filter = {"ps2AlertsEventType": {"$exists": false}};
     let updateDoc = [{"$set":{"ps2AlertsEventType": 1}}];
 
     console.log(updateDoc);
 
     for (const collection of aggregateCollections) {
       console.log(`Setting event types for collection ${collection}...`)
-      const result = await db.collection(collection).updateMany({}, updateDoc);
+      const result = await db.collection(collection).updateMany(filter, updateDoc);
       console.log(`Updated ${result.modifiedCount} documents`);
     }
   },

--- a/mongo/migrations/20220828152940-event_type_aggregate.js
+++ b/mongo/migrations/20220828152940-event_type_aggregate.js
@@ -45,7 +45,7 @@ module.exports = {
   },
 
   async down(db) {
-    let updateDoc = [{"$unset":{"ps2AlertsEventType": 1}}];
+    let updateDoc = [{"$unset": "ps2AlertsEventType"}];
     for (const collection of aggregateCollections) {
       await db.collection(collection).updateMany({}, updateDoc);
     }

--- a/mongo/migrations/20220831145705-add_event_type_to_aggregate_characters.js
+++ b/mongo/migrations/20220831145705-add_event_type_to_aggregate_characters.js
@@ -29,7 +29,7 @@ module.exports = {
   },
 
   async down(db) {
-    let updateDoc = [{"$unset":{"ps2AlertsEventType": 1}}];
+    let updateDoc = [{"$unset": "ps2AlertsEventType"}];
     for (const collection of aggregateCollections) {
       await db.collection(collection).updateMany({}, updateDoc);
     }

--- a/mongo/migrations/20220831145705-add_event_type_to_aggregate_characters.js
+++ b/mongo/migrations/20220831145705-add_event_type_to_aggregate_characters.js
@@ -5,6 +5,18 @@ const aggregateCollections = [
 
 module.exports = {
   async up(db) {
+    let filter = {"ps2AlertsEventType": {"$exists": true}};
+    for (let i = 0; i < aggregateCollections.length;) {
+      const collection = aggregateCollections[i];
+      const result = await db.collection(collection).findOne(filter);
+      if(result !== null) {
+        const index = aggregateCollections.indexOf(collection);
+        aggregateCollections.splice(index, 1);
+      } else {
+        i++;
+      }
+    }
+    filter = {"ps2AlertsEventType": {"$exists": false}};
     let updateDoc = [{"$set":{"ps2AlertsEventType": 1}}];
 
     console.log(updateDoc);

--- a/mongo/migrations/20230310220337-add_lattice_versions.js
+++ b/mongo/migrations/20230310220337-add_lattice_versions.js
@@ -1,0 +1,29 @@
+module.exports = {
+  async up(db) {
+    let filter = {"timeStarted": {"$lte": new Date(2022, 10, 17, 14)}, "latticeVersion": {"$exists": false}};
+    let updateDoc = [{"$set":{"latticeVersion": "$mapVersion"}}];
+
+    console.log(`Updating instances created prior to the November 17, 2022 Update...`);
+    let result = await db.collection("instance_metagame_territories").updateMany(filter, updateDoc);
+    console.log(`${result.matchedCount} document(s) matched the filter, updated ${result.modifiedCount} document(s)\n`);
+
+    filter = {"timeStarted": {"$gt": new Date(2022, 10, 17, 14)}, "latticeVersion": {"$exists": false}, "zone": {"$ne": 2}};
+    console.log(`Updating unversioned, non-Indar instances created after the November 17, 2022 Update...`);
+    result = await db.collection("instance_metagame_territories").updateMany(filter, updateDoc);
+    console.log(`${result.matchedCount} document(s) matched the filter, updated ${result.modifiedCount} document(s)\n`);
+
+    filter = {"timeStarted": {"$gt": new Date(2022, 10, 17, 14)}, "latticeVersion": {"$exists": false}, "zone": 2};
+    console.log(`Updating unversioned Indar instances created after the November 17, 2022 Update...`);
+    updateDoc = [{"$set":{"latticeVersion": "1.1"}}];
+    result = await db.collection("instance_metagame_territories").updateMany(filter, updateDoc);
+    console.log(`${result.matchedCount} document(s) matched the filter, updated ${result.modifiedCount} document(s)\n`);
+  },
+
+  async down(db) {
+    const updateDoc = [{"$unset":{"latticeVersion": 1}}];
+
+    console.log(`Removing latticeVersions from all alert instances...\n`);
+    const result = await db.collection("instance_metagame_territories").updateMany({}, updateDoc);
+    console.log(`Updated ${result.modifiedCount} document(s)\n`);
+  }
+};

--- a/mongo/migrations/20230310220337-add_lattice_versions.js
+++ b/mongo/migrations/20230310220337-add_lattice_versions.js
@@ -12,14 +12,15 @@ module.exports = {
       let result = await db.collection(collection).updateMany(filter, updateDoc);
       console.log(`${result.matchedCount} document(s) matched the filter, updated ${result.modifiedCount} document(s)\n`);
 
-      filter = {"timeStarted": {"$gt": new Date(2022, 10, 17, 14)}, "latticeVersion": {"$exists": false}, "zone": {"$ne": 2}};
-      console.log(`Updating unversioned, non-Indar instances created after the November 17, 2022 Update...`);
+      filter = {"timeStarted": {"$gt": new Date(2022, 10, 17, 14)}, "latticeVersion": {"$exists": false}, "zone": {"$ne": 344}};
+      console.log(`Updating unversioned, non-Oshur instances created after the November 17, 2022 Update...`);
+      updateDoc = [{"$set":{"latticeVersion": "1.1"}}];
       result = await db.collection(collection).updateMany(filter, updateDoc);
       console.log(`${result.matchedCount} document(s) matched the filter, updated ${result.modifiedCount} document(s)\n`);
 
-      filter = {"timeStarted": {"$gt": new Date(2022, 10, 17, 14)}, "latticeVersion": {"$exists": false}, "zone": 2};
-      console.log(`Updating unversioned Indar instances created after the November 17, 2022 Update...`);
-      updateDoc = [{"$set":{"latticeVersion": "1.1"}}];
+      filter = {"timeStarted": {"$gt": new Date(2022, 10, 17, 14)}, "latticeVersion": {"$exists": false}, "zone": 344};
+      console.log(`Updating unversioned Oshur instances created after the November 17, 2022 Update...`);
+      updateDoc = [{"$set":{"latticeVersion": "1.2"}}];
       result = await db.collection(collection).updateMany(filter, updateDoc);
       console.log(`${result.matchedCount} document(s) matched the filter, updated ${result.modifiedCount} document(s)\n`);
     }

--- a/mongo/migrations/20230310220337-add_lattice_versions.js
+++ b/mongo/migrations/20230310220337-add_lattice_versions.js
@@ -1,29 +1,37 @@
+const collections = [
+  "instance_metagame_territories",
+  "instance_outfitwars_2022"
+];
+
 module.exports = {
   async up(db) {
     let filter = {"timeStarted": {"$lte": new Date(2022, 10, 17, 14)}, "latticeVersion": {"$exists": false}};
     let updateDoc = [{"$set":{"latticeVersion": "$mapVersion"}}];
+    for(const collection of collections) {
+      console.log(`Updating instances created prior to the November 17, 2022 Update...`);
+      let result = await db.collection(collection).updateMany(filter, updateDoc);
+      console.log(`${result.matchedCount} document(s) matched the filter, updated ${result.modifiedCount} document(s)\n`);
 
-    console.log(`Updating instances created prior to the November 17, 2022 Update...`);
-    let result = await db.collection("instance_metagame_territories").updateMany(filter, updateDoc);
-    console.log(`${result.matchedCount} document(s) matched the filter, updated ${result.modifiedCount} document(s)\n`);
+      filter = {"timeStarted": {"$gt": new Date(2022, 10, 17, 14)}, "latticeVersion": {"$exists": false}, "zone": {"$ne": 2}};
+      console.log(`Updating unversioned, non-Indar instances created after the November 17, 2022 Update...`);
+      result = await db.collection(collection).updateMany(filter, updateDoc);
+      console.log(`${result.matchedCount} document(s) matched the filter, updated ${result.modifiedCount} document(s)\n`);
 
-    filter = {"timeStarted": {"$gt": new Date(2022, 10, 17, 14)}, "latticeVersion": {"$exists": false}, "zone": {"$ne": 2}};
-    console.log(`Updating unversioned, non-Indar instances created after the November 17, 2022 Update...`);
-    result = await db.collection("instance_metagame_territories").updateMany(filter, updateDoc);
-    console.log(`${result.matchedCount} document(s) matched the filter, updated ${result.modifiedCount} document(s)\n`);
-
-    filter = {"timeStarted": {"$gt": new Date(2022, 10, 17, 14)}, "latticeVersion": {"$exists": false}, "zone": 2};
-    console.log(`Updating unversioned Indar instances created after the November 17, 2022 Update...`);
-    updateDoc = [{"$set":{"latticeVersion": "1.1"}}];
-    result = await db.collection("instance_metagame_territories").updateMany(filter, updateDoc);
-    console.log(`${result.matchedCount} document(s) matched the filter, updated ${result.modifiedCount} document(s)\n`);
+      filter = {"timeStarted": {"$gt": new Date(2022, 10, 17, 14)}, "latticeVersion": {"$exists": false}, "zone": 2};
+      console.log(`Updating unversioned Indar instances created after the November 17, 2022 Update...`);
+      updateDoc = [{"$set":{"latticeVersion": "1.1"}}];
+      result = await db.collection(collection).updateMany(filter, updateDoc);
+      console.log(`${result.matchedCount} document(s) matched the filter, updated ${result.modifiedCount} document(s)\n`);
+    }
   },
 
   async down(db) {
     const updateDoc = [{"$unset": "latticeVersion"}];
 
     console.log(`Removing latticeVersions from all alert instances...\n`);
-    const result = await db.collection("instance_metagame_territories").updateMany({}, updateDoc);
-    console.log(`Updated ${result.modifiedCount} document(s)\n`);
+    for(const collection of collections) {
+      const result = await db.collection(collection).updateMany({}, updateDoc);
+      console.log(`Updated ${result.modifiedCount} document(s)\n`);
+    }
   }
 };

--- a/mongo/migrations/20230310220337-add_lattice_versions.js
+++ b/mongo/migrations/20230310220337-add_lattice_versions.js
@@ -20,7 +20,7 @@ module.exports = {
   },
 
   async down(db) {
-    const updateDoc = [{"$unset":{"latticeVersion": 1}}];
+    const updateDoc = [{"$unset": "latticeVersion"}];
 
     console.log(`Removing latticeVersions from all alert instances...\n`);
     const result = await db.collection("instance_metagame_territories").updateMany({}, updateDoc);


### PR DESCRIPTION
This PR adds a migration that will update all instances created after the November 17th 2022 update to use the new lattices with CTF bases.

Additionally a few migrations have been fixed to be able to be run on a fresh DB (say, one created for development purposes) that already contains the changes made by that migration